### PR TITLE
Adds a function to copy text from an existing element on the page

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -17,6 +17,12 @@
       <button class="test-selector" type="button" data-copy-text="From test-selector child#2!">
         Copy
       </button>
+      <div>
+          <input id="input-selector" type="text" value="Copy me!" />
+          <button id="input-button-selector" type="button">
+              Copy Text in Input
+          </button>
+      </div>
     </form>
   </body>
 </html>

--- a/example/index.html
+++ b/example/index.html
@@ -18,10 +18,10 @@
         Copy
       </button>
       <div>
-          <input id="input-selector" type="text" value="Copy me!" />
-          <button id="input-button-selector" type="button">
-              Copy Text in Input
-          </button>
+        <input id="input-selector" type="text" value="Copy me!" />
+        <button id="input-button-selector" type="button">
+          Copy Text in Input
+        </button>
       </div>
     </form>
   </body>

--- a/example/src/Main.purs
+++ b/example/src/Main.purs
@@ -2,22 +2,21 @@ module Main where
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
-
-import Data.Maybe (fromMaybe)
-
-import DOM (DOM)
 import CSS (Selector, fromString)
+import Clipboard as C
+import Control.Monad.Eff (Eff)
+import DOM (DOM)
 import DOM.Event.EventTarget (addEventListener, eventListener)
 import DOM.HTML (window)
 import DOM.HTML.Event.EventTypes (load)
 import DOM.HTML.Types (windowToEventTarget, htmlDocumentToDocument)
 import DOM.HTML.Window (document)
-import DOM.Node.NonElementParentNode (getElementById)
-import DOM.Node.Types (Element, ElementId(..), documentToNonElementParentNode)
 import DOM.Node.Element (getAttribute)
-
-import Clipboard as C
+import DOM.Node.NonElementParentNode (getElementById)
+import DOM.Node.Types (Element, ElementId(ElementId), documentToNonElementParentNode)
+import Data.Maybe (fromJust, fromMaybe)
+import Data.Newtype (wrap)
+import Partial.Unsafe (unsafePartial)
 
 onLoad :: forall eff. (Eff (dom :: DOM | eff) Unit) -> Eff (dom :: DOM | eff) Unit
 onLoad action
@@ -34,6 +33,13 @@ testElement el = void $ C.fromElement el $ stringFromAttr "data-copy-text" el
 testSelector :: forall eff. Selector -> Eff (dom :: DOM | eff) Unit
 testSelector sel = void $ C.fromCSSSelector sel $ stringFromAttr "data-copy-text"
 
+testInputSelector :: forall eff. Eff (dom :: DOM | eff) Unit
+testInputSelector = do
+ doc <- documentToNonElementParentNode <<< htmlDocumentToDocument <$> (document =<< window)
+ let getInput = unsafePartial fromJust <$> getElementById (wrap "input-selector") doc
+ button <- unsafePartial fromJust <$> getElementById (wrap "input-button-selector") doc
+ void $ C.fromElementWithTarget button getInput
+
 main :: forall eff. Eff (dom :: DOM | eff) Unit
 main = onLoad do
   win <- window
@@ -41,3 +47,4 @@ main = onLoad do
   element <- getElementById (ElementId "test-element") doc
   fromMaybe (pure unit) $ testElement <$> element
   testSelector $ fromString ".test-selector"
+  testInputSelector

--- a/src/Clipboard.js
+++ b/src/Clipboard.js
@@ -26,6 +26,17 @@ exports.fromStringSelector = makeFromX(function makeFromX$fromStringSelector (ef
   };
 });
 
+exports.fromElementWithTarget = function (el){
+    return function(targetSelector) {
+        return function() {
+            return new Clipboard(el, {
+                target: targetSelector
+            });
+        };
+    };
+};
+
+
 exports.destroy = function destroy (clipboard) {
   return function destroy$Eff () {
     clipboard.destroy();

--- a/src/Clipboard.js
+++ b/src/Clipboard.js
@@ -26,14 +26,14 @@ exports.fromStringSelector = makeFromX(function makeFromX$fromStringSelector (ef
   };
 });
 
-exports.fromElementWithTarget = function (el){
-    return function(targetSelector) {
-        return function() {
-            return new Clipboard(el, {
-                target: targetSelector
-            });
-        };
+exports.fromElementWithTarget = function (el) {
+  return function(targetSelector) {
+    return function() {
+      return new Clipboard(el, {
+        target: targetSelector
+      });
     };
+  };
 };
 
 

--- a/src/Clipboard.purs
+++ b/src/Clipboard.purs
@@ -38,7 +38,7 @@ foreign import fromStringSelector
 -- | copies the text inside the returned element to the clipboard.
 foreign import fromElementWithTarget
   :: forall eff
-  . Element
+   . Element
   -> Eff (dom :: DOM | eff) Element
   -> Eff (dom :: DOM | eff) Clipboard
 

--- a/src/Clipboard.purs
+++ b/src/Clipboard.purs
@@ -2,6 +2,7 @@ module Clipboard
   ( Clipboard
   , fromElement
   , fromCSSSelector
+  , fromElementWithTarget
   , destroy
   ) where
 
@@ -31,6 +32,14 @@ foreign import fromStringSelector
   :: forall eff
    . String
   -> (Element -> Eff (dom :: DOM | eff) String)
+  -> Eff (dom :: DOM | eff) Clipboard
+
+-- | Registers a click handler on an Event, which triggers the passed `Eff` and
+-- | copies the text inside the returned element to the clipboard.
+foreign import fromElementWithTarget
+  :: forall eff
+  . Element
+  -> Eff (dom :: DOM | eff) Element
   -> Eff (dom :: DOM | eff) Clipboard
 
 foreign import destroy


### PR DESCRIPTION
This seems to be less fragile then the temporary element creation hack the `fromString` functions use.